### PR TITLE
Support usage as a Mix Archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ Now you can build your Dash.app documentation using the `docs.dash` task and it 
 
     MIX_ENV=docs mix docs.dash
 
+### As a global archive
+
+Check out ExDocDash and install as a global dependency
+
+    git clone https://github.com/JonGretar/ExDocDash.git
+    cd ExDocDash
+    mix do deps.get, archive.build, archive.install
+
+Now you should have the `docs.dash` mix task available in all projects.
+
+**Note that these projects will have to have `ex_doc` and `earmark` as it's dependency as it's not globally installed.**
+
 ## Example of generating [Phoenix](https://github.com/phoenixframework/phoenix) Documentation
 
 ![ExDocDash Phoenix docs](https://us-east.manta.joyent.com/JonGretar/public/ExDocDash-Phoenix-1.gif)

--- a/lib/ex_doc_dash/formatter/dash.ex
+++ b/lib/ex_doc_dash/formatter/dash.ex
@@ -36,9 +36,7 @@ defmodule ExDocDash.Formatter.Dash do
 		generate_list(:protocols, protocols, all, output, config, has_readme)
 
 		content = Templates.info_plist(config, has_readme)
-		path = "#{output}/../../Info.plist"
-		log(path)
-		:ok = File.write(path, content)
+		"#{output}/../../Info.plist" |> log |> File.write(content)
 
 		config.formatter_opts[:docset_root]
 	end
@@ -61,9 +59,7 @@ defmodule ExDocDash.Formatter.Dash do
 
 	defp generate_overview(modules, exceptions, protocols, output, config) do
 		content = Templates.overview_template(config, modules, exceptions, protocols)
-		path = "#{output}/overview.html"
-		log(path)
-		:ok = File.write(path, content)
+		"#{output}/overview.html" |> log |> File.write(content)
 	end
 
 	@assets Enum.map Util.assets, fn({ pattern, dir }) ->
@@ -99,8 +95,7 @@ defmodule ExDocDash.Formatter.Dash do
 		destination_path = Path.join(config.formatter_opts[:docset_root], "icon.tiff")
 		custom_icon_path = Path.join(config.source_root, "icon.tiff")
 		if File.exists?(custom_icon_path) do
-			log(custom_icon_path)
-			File.cp(custom_icon_path, destination_path)
+			custom_icon_path |> log |> File.cp(destination_path)
 		else
 			create_file destination_path, default_icon_text()
 		end
@@ -117,9 +112,7 @@ defmodule ExDocDash.Formatter.Dash do
 	defp write_readme(output, {:ok, content}, modules, config) do
 		content = Autolink.project_doc(content, modules)
 		readme_html = Templates.readme_template(config, content) |> pretty_codeblocks
-		path = "#{output}/README.html"
-		log(path)
-		File.write(path, readme_html)
+		"#{output}/README.html" |> log |> File.write(readme_html)
 		true
 	end
 
@@ -165,9 +158,7 @@ defmodule ExDocDash.Formatter.Dash do
 		Enum.each nodes, &index_list(&1, all, output, config)
 		Enum.each nodes, &generate_module_page(&1, all, output, config)
 		content = Templates.list_page(scope, nodes, config, has_readme)
-		path = "#{output}/#{scope}_list.html"
-		log(path)
-		File.write(path, content)
+		"#{output}/#{scope}_list.html" |> log |> File.write(content)
 	end
 
 	defp index_list(%ExDoc.FunctionNode{}=node, module, config) do
@@ -194,13 +185,12 @@ defmodule ExDocDash.Formatter.Dash do
 
 	defp generate_module_page(node, modules, output, config) do
 		content = Templates.module_page(node, config, modules)
-		path = "#{output}/#{node.id}.html"
-		log(path)
-		File.write(path, content)
+		"#{output}/#{node.id}.html" |> log |> File.write(content)
 	end
 
 	defp log(path) do
 		cwd = File.cwd!
 		Mix.shell.info [:green, "* creating ", :reset, Path.relative_to(path, cwd)]
+		path
 	end
 end

--- a/lib/ex_doc_dash/formatter/dash.ex
+++ b/lib/ex_doc_dash/formatter/dash.ex
@@ -36,7 +36,9 @@ defmodule ExDocDash.Formatter.Dash do
 		generate_list(:protocols, protocols, all, output, config, has_readme)
 
 		content = Templates.info_plist(config, has_readme)
-		:ok = File.write("#{output}/../../Info.plist", content)
+		path = "#{output}/../../Info.plist"
+		log(path)
+		:ok = File.write(path, content)
 
 		config.formatter_opts[:docset_root]
 	end
@@ -59,7 +61,9 @@ defmodule ExDocDash.Formatter.Dash do
 
 	defp generate_overview(modules, exceptions, protocols, output, config) do
 		content = Templates.overview_template(config, modules, exceptions, protocols)
-		:ok = File.write("#{output}/overview.html", content)
+		path = "#{output}/overview.html"
+		log(path)
+		:ok = File.write(path, content)
 	end
 
 	@assets Enum.map Util.assets, fn({ pattern, dir }) ->
@@ -95,6 +99,7 @@ defmodule ExDocDash.Formatter.Dash do
 		destination_path = Path.join(config.formatter_opts[:docset_root], "icon.tiff")
 		custom_icon_path = Path.join(config.source_root, "icon.tiff")
 		if File.exists?(custom_icon_path) do
+			log(custom_icon_path)
 			File.cp(custom_icon_path, destination_path)
 		else
 			create_file destination_path, default_icon_text()
@@ -112,7 +117,9 @@ defmodule ExDocDash.Formatter.Dash do
 	defp write_readme(output, {:ok, content}, modules, config) do
 		content = Autolink.project_doc(content, modules)
 		readme_html = Templates.readme_template(config, content) |> pretty_codeblocks
-		File.write("#{output}/README.html", readme_html)
+		path = "#{output}/README.html"
+		log(path)
+		File.write(path, readme_html)
 		true
 	end
 
@@ -158,7 +165,9 @@ defmodule ExDocDash.Formatter.Dash do
 		Enum.each nodes, &index_list(&1, all, output, config)
 		Enum.each nodes, &generate_module_page(&1, all, output, config)
 		content = Templates.list_page(scope, nodes, config, has_readme)
-		File.write("#{output}/#{scope}_list.html", content)
+		path = "#{output}/#{scope}_list.html"
+		log(path)
+		File.write(path, content)
 	end
 
 	defp index_list(%ExDoc.FunctionNode{}=node, module, config) do
@@ -185,10 +194,13 @@ defmodule ExDocDash.Formatter.Dash do
 
 	defp generate_module_page(node, modules, output, config) do
 		content = Templates.module_page(node, config, modules)
-		File.write("#{output}/#{node.id}.html", content)
+		path = "#{output}/#{node.id}.html"
+		log(path)
+		File.write(path, content)
 	end
 
-	defp templates_path(other) do
-		Path.expand(other, Application.app_dir(:ex_doc_dash, "priv/templates"))
+	defp log(path) do
+		cwd = File.cwd!
+		Mix.shell.info [:green, "* creating ", :reset, Path.relative_to(path, cwd)]
 	end
 end

--- a/lib/ex_doc_dash/util.ex
+++ b/lib/ex_doc_dash/util.ex
@@ -1,0 +1,23 @@
+defmodule ExDocDash.Util do
+
+	def templates_path(other) do
+		Path.expand(other, Application.app_dir(:ex_doc_dash, "priv/templates"))
+	end
+
+	def assets do
+		[
+			{ templates_path("stylesheets/*.css"), "stylesheets" },
+			{ templates_path("javascripts/*.js"), "javascripts" },
+			{ templates_path("fonts/*"), "fonts" }
+		]
+	end
+
+	defmacro get_content(file_func) do
+		quote bind_quoted: binding do
+			defp do_get_content(unquote(:"#{file_func}")) do
+				unquote(file_func)()
+			end
+		end
+	end
+
+end


### PR DESCRIPTION
Solved issue #3.

Since we can't read file in the `/priv` dir from the zipped archive file, but we can do this by embedding them into the module during the compile time, by using macro `embed_text` and function `create_file` in `Mix.Generator` module.
