### PR TITLE
Remove earmark dependency since ExDoc already defines it

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,8 +22,7 @@ defmodule ExDocDash.Mixfile do
 
 	defp deps do
 		[
-			{:ex_doc, ">= 0.9.0"},
-			{:earmark, "~> 0.1.17 or ~> 0.2"}
+			{:ex_doc, ">= 0.12.0"}
 		]
 	end
 


### PR DESCRIPTION
Starting in v 0.12.0, `ExDoc` has `Earmark` as a dependency. Since it's used only indirectly here by calling `ExDoc.Markdown.to_html/1`, we can leave it to ExDoc.
